### PR TITLE
Add custom package options links

### DIFF
--- a/resources/views/admin/layouts/sidebar/service_provider.blade.php
+++ b/resources/views/admin/layouts/sidebar/service_provider.blade.php
@@ -60,6 +60,13 @@
         </a>
     </li>
 
+    <li class="{{ request()->routeIs('package-options.edit') || request()->routeIs('provider.conditions.edit') ? 'menuitem-active' : '' }}">
+        <a href="{{ route('package-options.edit') }}" class="{{ request()->routeIs('package-options.edit') || request()->routeIs('provider.conditions.edit') ? 'active' : '' }}">
+            <i data-feather="sliders"></i>
+            <span> Package Options </span>
+        </a>
+    </li>
+
      <li class="{{ request()->routeIs('packages.*') ? 'menuitem-active' : '' }}">
         <a href="{{ route('packages.index') }}" class="{{ request()->routeIs('available-services.*') ? 'active' : '' }}">
             <i data-feather="globe"></i>

--- a/resources/views/frontend/provider-detail.blade.php
+++ b/resources/views/frontend/provider-detail.blade.php
@@ -184,6 +184,15 @@
                                         </div>
                                     @endforeach
                                 </div>
+                                <div class="text-end my-3">
+                                    @auth
+                                        <a href="{{ route('custom-packages.create', $provider) }}" class="btn btn-warning">
+                                            Request Custom Package
+                                        </a>
+                                    @else
+                                        <a href="{{ route('login') }}" class="btn btn-warning">Login to Request Custom Package</a>
+                                    @endauth
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,6 +66,9 @@ Route::group(['middleware' => 'auth'], function () {
 
     Route::get('/provider/conditions', [ServiceProviderConditionController::class, 'index'])->name('provider.conditions.edit');
     Route::post('/provider/conditions', [ServiceProviderConditionController::class, 'store'])->name('provider.conditions.update');
+    // Alternative routes to manage custom package options
+    Route::get('/provider/package-options', [ServiceProviderConditionController::class, 'index'])->name('package-options.edit');
+    Route::post('/provider/package-options', [ServiceProviderConditionController::class, 'store'])->name('package-options.update');
 
     Route::get('/providers/{provider}/custom-packages/create', [CustomPackageController::class, 'create'])->name('custom-packages.create');
     Route::post('/providers/{provider}/custom-packages', [CustomPackageController::class, 'store'])->name('custom-packages.store');


### PR DESCRIPTION
## Summary
- add alternative routes for editing service provider package options
- show link to package options on provider sidebar
- allow requesting custom package on provider detail page
