### PR TITLE
Add custom package options

### DIFF
--- a/app/Http/Controllers/PackageOptionController.php
+++ b/app/Http/Controllers/PackageOptionController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PackageOption;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PackageOptionController extends Controller
+{
+    public function index()
+    {
+        $options = PackageOption::where('service_provider_id', Auth::id())->get();
+        return view('provider.package-options.edit', compact('options'));
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'options' => 'required|array',
+            'options.*.name' => 'required|string',
+            'options.*.base_price' => 'required|numeric',
+        ]);
+
+        PackageOption::where('service_provider_id', Auth::id())->delete();
+
+        foreach ($request->options as $option) {
+            PackageOption::create([
+                'service_provider_id' => Auth::id(),
+                'name' => $option['name'],
+                'base_price' => $option['base_price'],
+            ]);
+        }
+
+        return redirect()->route('package-options.edit')->with('success', 'Options saved.');
+    }
+}

--- a/app/Models/CustomPackage.php
+++ b/app/Models/CustomPackage.php
@@ -12,6 +12,7 @@ class CustomPackage extends Model
         'name',
         'description',
         'features',
+        'options',
         'price',
         'stripe_payment_id',
         'payment_status',
@@ -19,6 +20,7 @@ class CustomPackage extends Model
 
     protected $casts = [
         'features' => 'array',
+        'options' => 'array',
     ];
 
     public function provider()

--- a/app/Models/PackageOption.php
+++ b/app/Models/PackageOption.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PackageOption extends Model
+{
+    protected $fillable = [
+        'service_provider_id',
+        'name',
+        'base_price',
+    ];
+
+    public function provider()
+    {
+        return $this->belongsTo(User::class, 'service_provider_id');
+    }
+}

--- a/database/migrations/2025_07_28_140938_create_package_options_table.php
+++ b/database/migrations/2025_07_28_140938_create_package_options_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('package_options', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('service_provider_id');
+            $table->string('name');
+            $table->decimal('base_price', 8, 2)->default(0);
+            $table->timestamps();
+
+            $table->foreign('service_provider_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('package_options');
+    }
+};

--- a/database/migrations/2025_07_28_140949_add_options_to_custom_packages_table.php
+++ b/database/migrations/2025_07_28_140949_add_options_to_custom_packages_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('custom_packages', function (Blueprint $table) {
+            $table->json('options')->nullable()->after('features');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('custom_packages', function (Blueprint $table) {
+            $table->dropColumn('options');
+        });
+    }
+};

--- a/resources/views/custom-packages/create.blade.php
+++ b/resources/views/custom-packages/create.blade.php
@@ -16,11 +16,35 @@
             <label class="form-label">Features (comma separated)</label>
             <input type="text" name="features[]" class="form-control">
         </div>
+
+        @if($options->count())
+            <h5>Options</h5>
+            @foreach($options as $option)
+                <div class="mb-3">
+                    <label class="form-label">{{ $option->name }} (${{ number_format($option->base_price,2) }} each)</label>
+                    <input type="number" min="0" name="options[{{ $option->id }}]" value="0" class="form-control option-input" data-price="{{ $option->base_price }}">
+                </div>
+            @endforeach
+        @endif
+
         <div class="mb-3">
-            <label class="form-label">Price</label>
-            <input type="number" step="0.01" name="price" class="form-control" value="{{ $condition->base_price ?? '' }}" required>
+            <label class="form-label">Total Price</label>
+            <input type="number" step="0.01" name="price" id="total_price" class="form-control" readonly>
         </div>
         <button class="btn btn-primary">Create</button>
     </form>
 </div>
+<script>
+function updateTotal(){
+    let total = 0;
+    document.querySelectorAll('.option-input').forEach(el => {
+        const qty = parseInt(el.value) || 0;
+        const price = parseFloat(el.dataset.price);
+        total += qty * price;
+    });
+    document.getElementById('total_price').value = total.toFixed(2);
+}
+document.querySelectorAll('.option-input').forEach(el => el.addEventListener('input', updateTotal));
+updateTotal();
+</script>
 @endsection

--- a/resources/views/custom-packages/edit.blade.php
+++ b/resources/views/custom-packages/edit.blade.php
@@ -17,11 +17,39 @@
             <label class="form-label">Features (comma separated)</label>
             <input type="text" name="features[]" class="form-control" value="{{ implode(',', $customPackage->features ?? []) }}">
         </div>
+
+        @if($options->count())
+            <h5>Options</h5>
+            @foreach($options as $option)
+                @php
+                    $selected = collect($customPackage->options)->firstWhere('option_id', $option->id);
+                    $qty = $selected['quantity'] ?? 0;
+                @endphp
+                <div class="mb-3">
+                    <label class="form-label">{{ $option->name }} (${{ number_format($option->base_price,2) }} each)</label>
+                    <input type="number" min="0" name="options[{{ $option->id }}]" value="{{ $qty }}" class="form-control option-input" data-price="{{ $option->base_price }}">
+                </div>
+            @endforeach
+        @endif
+
         <div class="mb-3">
-            <label class="form-label">Price</label>
-            <input type="number" step="0.01" name="price" class="form-control" value="{{ old('price', $customPackage->price) }}" required>
+            <label class="form-label">Total Price</label>
+            <input type="number" step="0.01" name="price" id="total_price" class="form-control" value="{{ $customPackage->price }}" readonly>
         </div>
         <button class="btn btn-primary">Update</button>
     </form>
 </div>
+<script>
+function updateTotal(){
+    let total = 0;
+    document.querySelectorAll('.option-input').forEach(el => {
+        const qty = parseInt(el.value) || 0;
+        const price = parseFloat(el.dataset.price);
+        total += qty * price;
+    });
+    document.getElementById('total_price').value = total.toFixed(2);
+}
+document.querySelectorAll('.option-input').forEach(el => el.addEventListener('input', updateTotal));
+updateTotal();
+</script>
 @endsection

--- a/resources/views/custom-packages/show.blade.php
+++ b/resources/views/custom-packages/show.blade.php
@@ -8,6 +8,14 @@
             <li>{{ $feature }}</li>
         @endforeach
     </ul>
+    @if($customPackage->options)
+        <h6>Selected Options</h6>
+        <ul>
+            @foreach($customPackage->options as $opt)
+                <li>{{ $opt['name'] }} x {{ $opt['quantity'] }} ({{ $opt['unit_price'] }})</li>
+            @endforeach
+        </ul>
+    @endif
     <p>Price: {{ $customPackage->price }}</p>
     @if($customPackage->payment_status === 'pending')
         <form method="POST" action="{{ route('custom-packages.pay', $customPackage) }}">

--- a/resources/views/provider/package-options/edit.blade.php
+++ b/resources/views/provider/package-options/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+@section('content')
+<div class="container">
+    <h4 class="mb-3">Custom Package Options</h4>
+    <form method="POST" action="{{ route('package-options.update') }}">
+        @csrf
+        <div id="options-wrapper">
+            @foreach($options as $index => $option)
+                <div class="row mb-2 option-row">
+                    <div class="col">
+                        <input type="text" name="options[{{ $index }}][name]" class="form-control" value="{{ $option->name }}" placeholder="Option name">
+                    </div>
+                    <div class="col">
+                        <input type="number" step="0.01" name="options[{{ $index }}][base_price]" class="form-control" value="{{ $option->base_price }}" placeholder="Base Price">
+                    </div>
+                </div>
+            @endforeach
+        </div>
+        <button type="button" class="btn btn-sm btn-secondary" id="add-option">Add Option</button>
+        <button class="btn btn-primary">Save</button>
+    </form>
+</div>
+<script>
+document.getElementById('add-option').addEventListener('click', function(){
+    let wrapper = document.getElementById('options-wrapper');
+    let index = wrapper.querySelectorAll('.option-row').length;
+    let div = document.createElement('div');
+    div.className = 'row mb-2 option-row';
+    div.innerHTML = `<div class="col"><input type="text" name="options[${index}][name]" class="form-control" placeholder="Option name"></div><div class="col"><input type="number" step="0.01" name="options[${index}][base_price]" class="form-control" placeholder="Base Price"></div>`;
+    wrapper.appendChild(div);
+});
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\ProviderProfileController;
 use App\Http\Controllers\ReviewController;
 use App\Http\Controllers\ServiceController;
 use App\Http\Controllers\ServiceProviderConditionController;
+use App\Http\Controllers\PackageOptionController;
 use App\Http\Controllers\ServicesController;
 use GuzzleHttp\Middleware;
 use Illuminate\Support\Facades\Route;
@@ -66,9 +67,9 @@ Route::group(['middleware' => 'auth'], function () {
 
     Route::get('/provider/conditions', [ServiceProviderConditionController::class, 'index'])->name('provider.conditions.edit');
     Route::post('/provider/conditions', [ServiceProviderConditionController::class, 'store'])->name('provider.conditions.update');
-    // Alternative routes to manage custom package options
-    Route::get('/provider/package-options', [ServiceProviderConditionController::class, 'index'])->name('package-options.edit');
-    Route::post('/provider/package-options', [ServiceProviderConditionController::class, 'store'])->name('package-options.update');
+    // Routes to manage custom package options
+    Route::get('/provider/package-options', [PackageOptionController::class, 'index'])->name('package-options.edit');
+    Route::post('/provider/package-options', [PackageOptionController::class, 'store'])->name('package-options.update');
 
     Route::get('/providers/{provider}/custom-packages/create', [CustomPackageController::class, 'create'])->name('custom-packages.create');
     Route::post('/providers/{provider}/custom-packages', [CustomPackageController::class, 'store'])->name('custom-packages.store');

--- a/tests/Feature/CustomPackage/OptionPriceTest.php
+++ b/tests/Feature/CustomPackage/OptionPriceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+test('custom package price is calculated from options', function () {
+    $provider = \App\Models\User::factory()->create();
+    $user = \App\Models\User::factory()->create();
+
+    \App\Models\PackageOption::create([
+        'service_provider_id' => $provider->id,
+        'name' => 'Photo',
+        'base_price' => 2,
+    ]);
+
+    $response = $this->actingAs($user)->post(route('custom-packages.store', $provider), [
+        'name' => 'My Package',
+        'description' => 'desc',
+        'features' => [],
+        'options' => [1 => 3],
+    ]);
+
+    $package = \App\Models\CustomPackage::first();
+    expect($package->price)->toBe(6.0);
+});


### PR DESCRIPTION
## Summary
- allow service providers to define custom package options
- calculate custom package price from selected options
- show/edit package options in the dashboard
- adjust custom package creation and editing views
- support options on custom packages with new migrations
- add basic test for option pricing